### PR TITLE
Clarify selection of Trace IDs in error traces

### DIFF
--- a/breakout_1_Introduction-to-Grafana-Observability/breakout_1_answers/2.3-app-o11y.md
+++ b/breakout_1_Introduction-to-Grafana-Observability/breakout_1_answers/2.3-app-o11y.md
@@ -18,7 +18,7 @@ To find this:
 
         ![Errorsl](/images/breakout_1/2.3-app-o11y-1.png)
 
-    1. Click on any of the `Trace ID`s within the table - they all show error traces from the Productcatalog Service
+    1. Expand any of the `Trace ID`s within the table and select the associated 'spanID'  - they all show error traces from the Productcatalog Service
 
         ![Span Detail](/images/breakout_1/2.3-app-o11y-2.png)
       


### PR DESCRIPTION
Updated instructions to clarify that you must expand Trace ID AND select spanID to display the trace side by side